### PR TITLE
Hotfix/unable to import

### DIFF
--- a/spec/timezone_spec.rb
+++ b/spec/timezone_spec.rb
@@ -54,21 +54,21 @@ describe Icalendar::Timezone do
         expect(first_standard.valid?).to be_truthy
         expect(first_daylight.valid?).to be_truthy
 
-        # calling previous_occurrence intializes @cached_occurrences with a time that's not handled by ruby marshaller
+        # calling previous_or_next_occurrence intializes @cached_occurrences with a time that's not handled by ruby marshaller
         first_occurence_for = Time.new(1601, 10, 31)
 
-        standard_previous_occurrence = first_standard.previous_occurrence(first_occurence_for)
-        expect(standard_previous_occurrence).not_to be_nil
+        standard_previous_or_next_occurrence = first_standard.previous_or_next_occurrence(first_occurence_for)
+        expect(standard_previous_or_next_occurrence).not_to be_nil
 
-        daylight_previous_occurrence = first_daylight.previous_occurrence(first_occurence_for)
-        expect(daylight_previous_occurrence).not_to be_nil
+        daylight_previous_or_next_occurrence = first_daylight.previous_or_next_occurrence(first_occurence_for)
+        expect(daylight_previous_or_next_occurrence).not_to be_nil
 
         deserialized = nil
 
         expect { deserialized = Marshal.load(Marshal.dump(subject)) }.not_to raise_exception
 
-        expect(deserialized.standards.first.previous_occurrence(first_occurence_for)).to eq(standard_previous_occurrence)
-        expect(deserialized.daylights.first.previous_occurrence(first_occurence_for)).to eq(daylight_previous_occurrence)
+        expect(deserialized.standards.first.previous_or_next_occurrence(first_occurence_for)).to eq(standard_previous_or_next_occurrence)
+        expect(deserialized.daylights.first.previous_or_next_occurrence(first_occurence_for)).to eq(daylight_previous_or_next_occurrence)
       end
     end
 


### PR DESCRIPTION
Importing an ICS from http://www.mychurchevents.com/calendar/ical/73820654/public.ics?tz=z85 will result in an exception being thrown because @cached_occurrences.reverse_each.find { |occurrence| occurrence < from } always returns nil.

This PR makes it so that if it is nil, return the next occurrence instead of the previous one.